### PR TITLE
Restrict kubernetes dependabot updates on 1.19 release branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,14 @@
 #
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "04:00"
-  target-branch: master
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: weekly
+    interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
+  target_branch: release-v1.19.x
   ignore:
   - dependency-name: k8s.io/*
     versions:
-    - ">=0.19.0"
+    - ">0.19.0"


### PR DESCRIPTION
We should only get 1.19 updates on `release-v1.19.x`. I will add 1.20 once that branch is set up.