### PR TITLE
Allow dependabot to update Kubernetes v1.20 patch version on master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,3 @@
-# DO NOT EDIT. Generated with:
-#
-#    devctl gen dependabot
-#
 version: 2
 updates:
 - package-ecosystem: gomod
@@ -15,3 +11,14 @@ updates:
   - dependency-name: k8s.io/*
     versions:
     - ">0.19.0"
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10
+  target_branch: master
+  ignore:
+  - dependency-name: k8s.io/*
+    versions:
+    - ">0.20.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.20.0] - 2020-12-09
 
+### Changed
+
+- Update to Kubernetes 1.20.0.
+
 ## [1.19.4] - 2020-12-09
 
 ### Added


### PR DESCRIPTION
Tying 1.20 to `master`. When 1.21 is out, we'll change it to the `release-v1.20.x` branch and change master to 1.21.