### PR TITLE
Fix target branch typo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
-  target_branch: release-v1.19.x
+  target-branch: release-v1.19.x
   ignore:
   - dependency-name: k8s.io/*
     versions:
@@ -17,7 +17,7 @@ updates:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
-  target_branch: master
+  target-branch: master
   ignore:
   - dependency-name: k8s.io/*
     versions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /tmp/hyperkube
 COPY go.mod go.mod
 
 RUN KUBERNETES_VERSION=$(cat go.mod | grep k8s.io/kubectl | cut -d ' ' -f 3 | sed 's/v0./v1./') && \
-    wget https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubelet && \
-    wget https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && \
+    wget -t 5 https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubelet && \
+    wget -t 5 https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && \
     chmod +x /tmp/hyperkube/kubelet /tmp/hyperkube/kubectl
 
 FROM scratch


### PR DESCRIPTION
Dependabot is unhappy because `target_branch` should be `target-branch`. There have been some CI failures due to closed connections so I also added wget retries for improved reliability.