### PR TITLE
Ignore correct minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   ignore:
   - dependency-name: k8s.io/*
     versions:
-    - ">0.19.0"
+    - ">=0.20.0"
 - package-ecosystem: gomod
   directory: "/"
   schedule:
@@ -21,4 +21,4 @@ updates:
   ignore:
   - dependency-name: k8s.io/*
     versions:
-    - ">0.20.0"
+    - ">=0.21.0"


### PR DESCRIPTION
We're not getting a Dependabot PR for k8s 1.19.5 which was released a few days ago. It seems that the `release-1.19.x` branch should ignore `>=0.20.0` rather than `>0.19.0`. Same for `master`.
